### PR TITLE
Fix reactions layout by adding reflow & cleanup logs

### DIFF
--- a/src/modules/moderators/moderator.module.ts
+++ b/src/modules/moderators/moderator.module.ts
@@ -1,9 +1,7 @@
 export function checkForModeratorMessages(message: HTMLElement) {
 
-    console.log('Checking for moderator messages');
-
     if (message.dataset.moderatorChecked === 'true') {
-        console.log('Already checked this message');
+        return;
     }
     message.dataset.moderatorChecked = 'true';
 
@@ -13,7 +11,6 @@ export function checkForModeratorMessages(message: HTMLElement) {
     // Look for moderator avatar
     const moderatorAvatar = parent.querySelector('[data-test="moderatorAvatar"]');
     if (moderatorAvatar) {
-        console.log('Found moderator message');
         addClassModerator(parent);
     }
 }

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -1,0 +1,31 @@
+/**
+ * This function will force a reflow of the chat messages by recalculating the position of each drawn message from the modified message to the top to avoid overlapping.
+ * @param messageContainer
+ */
+export function forceReflow(messageContainer?: HTMLElement) {
+    if (!messageContainer) return;
+
+    // 1. Get parent span of the modified message
+    const modifiedSpan = messageContainer.closest<HTMLElement>('[role="listitem"]');
+    if (!modifiedSpan) return;
+
+    // 2. Update the height of the modified message because it's not updated automatically
+    const innerDiv = modifiedSpan.querySelector<HTMLElement>('.sc-leYdVB');
+    if (innerDiv) {
+        modifiedSpan.style.height = `${innerDiv.offsetHeight}px`;
+    }
+
+    // 3. Get all messages
+    const chatContainer = document.querySelector('[data-test="chatMessages"]');
+    if (!chatContainer) return;
+
+    const allMessages = Array.from(chatContainer.querySelectorAll<HTMLElement>('[role="listitem"]'));
+    const modifiedIndex = allMessages.indexOf(modifiedSpan);
+
+    // 4. Update the position of each message from the modified message to the top
+    for (let i = modifiedIndex - 1; i >= 0; i--) {
+        const messageSpan = allMessages[i];
+        const newTop = parseFloat(allMessages[i + 1].style.top) - messageSpan.offsetHeight;
+        messageSpan.style.top = `${newTop}px`;
+    }
+}


### PR DESCRIPTION
This PR improves the chat's reaction system by:

- Adding a reflow mechanism to correctly reposition messages when reactions are added
- Fix overlapping messages issue by recalculating previous messages positions → #4 
- Remove debug console.log statements

Technical changes:
- Implement forceReflow utility to handle message repositioning
- Update message containers heights based on their content
- Recalculate positions of previous messages to maintain layout integrity
- Clean up debugging logs